### PR TITLE
Add Apple Silicon YAML files and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ Supervisor: jrhartog@uw.edu
 Primary editor: ntsteven@uw.edu  
 
 # Supporting Repositories
-## SeisBench  
-https://github.com/seisbench
-## PNW-ML
+### SeisBench  
+https://github.com/seisbench/seisbench
+### PNW-ML
 https://github.com/niyiyu/PNW-ML
 
 # References
+#### SeisBench
 Jack Woollam, Jannes Münchmeyer, Frederik Tilmann, Andreas Rietbrock, Dietrich Lange, Thomas Bornstein, Tobias Diehl, Carlo Giunchi, Florian Haslinger, Dario Jozinović, Alberto Michelini, Joachim Saul, Hugo Soto; SeisBench—A Toolbox for Machine Learning in Seismology. Seismological Research Letters 2022;; 93 (3): 1695–1709. doi: https://doi.org/10.1785/0220210324
 
+#### PNW Store
 Ni, Y., Hutko, A., Skene, F., Denolle, M., Malone, S., Bodin, P., Hartog, R., & Wright, A. (2023). Curated Pacific Northwest AI-ready Seismic Dataset. Seismica, 2(1). https://doi.org/10.26443/seismica.v2i1.368

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ PNSN Science Products team Machine Learning workflows/utilities
  - Includes notes on environment installation on Apple M1/M2 chips (a `TensorFlow` concern).
 
 # Contact Info
-Supervisor: jrhartog@uw.edu
-Primary editor: ntsteven@uw.edu
+Supervisor: jrhartog@uw.edu  
+Primary editor: ntsteven@uw.edu  
 
 # Supporting Repositories
 ## SeisBench  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Sci-Prod-ML
 PNSN Science Products team Machine Learning workflows/utilities
 
+# Contents
+### environments/
+ - Instructions for building conda environments for ML workflows in this repository.
+ - Includes notes on environment installation on Apple M1/M2 chips (a `TensorFlow` concern).
+
 # Contact Info
 Supervisor: jrhartog@uw.edu
 Primary editor: ntsteven@uw.edu

--- a/environments/TensorFlow_AppleSilicon_Install.md
+++ b/environments/TensorFlow_AppleSilicon_Install.md
@@ -1,8 +1,8 @@
-Purpose: brief instructions on how to install TensorFlow (and most modern ML modules) on Apple M1/M2 chipsets.
+**Purpose**: brief instructions on how to install TensorFlow (and most modern ML modules) on Apple M1/M2 chipsets.
 
 **Note**: This uses an adapted version of the environment.yml from ESS 469 (`environments/environment_AppleM1.yml`) that has been tested on a MacBook Air with M1 (2020) and a light-weight install using the environment proposed in Reference (1) (`environments/environment_TF_Apple.yml`).
 
-
+## Method
 Follow macOS-side installation instructions from references (2) & (3)  
     1. Install xcode command line tools  
         `xcode-select --install`  
@@ -10,13 +10,20 @@ Follow macOS-side installation instructions from references (2) & (3)
     3. Then turn off the default base environment (ref 2)  
         `conda config --set auto_activate_base false`  
     
-Run this version of `conda env create` from the comments and gist in references (1) & (4), respectively  
+Run the following version of `conda env create` from the comments and gist in references (1) & (4), respectively  
 `CONDA_SUBDIR=osx-arm64 conda env create -f environment_AppleM1.yml`
 
 ## Known issues
-Conducting step 3. appears to require using the full path to conda environments to invoke `conda activate <my_env>` which can be found using `conda env --list`.
+Conducting step 3. appears to require using the full path to conda environments to invoke:  
+`conda activate <my_env>`  
+e.g.,  
+`conda activate /Users/nates/miniconda3/envs/seisbench`  
 
-## Contact Information
+These paths can be found using  
+`conda env list`  
+
+## Compiler Contact Information
+Nathan Stevens:
 ntsteven@uw.edu
 
 ## References

--- a/environments/TensorFlow_AppleSilicon_Install.md
+++ b/environments/TensorFlow_AppleSilicon_Install.md
@@ -27,7 +27,7 @@ Nathan Stevens:
 ntsteven@uw.edu
 
 ## References
-environment_AppleM1.yml install instructions based on: 
+environment_AppleM1.yml install instructions based on:  
 (1) https://gist.github.com/corajr/a10af2f893c4b79275281f6b6fd915d3  
 (2) https://caffeinedev.medium.com/how-to-install-tensorflow-on-m1-mac-8e9b91d93706  
 (3) https://github.com/conda-forge/miniforge  

--- a/environments/TensorFlow_AppleSilicon_Install.md
+++ b/environments/TensorFlow_AppleSilicon_Install.md
@@ -1,0 +1,27 @@
+Purpose: brief instructions on how to install TensorFlow (and most modern ML modules) on Apple M1/M2 chipsets.
+
+**Note**: This uses an adapted version of the environment.yml from ESS 469 (`environments/environment_AppleM1.yml`) that has been tested on a MacBook Air with M1 (2020) and a light-weight install using the environment proposed in Reference (1) (`environments/environment_TF_Apple.yml`).
+
+
+Follow macOS-side installation instructions from references (2) & (3)  
+    1. Install xcode command line tools  
+        `xcode-select --install`  
+    2. Install Miniforge - follow instructions in reference (4)  
+    3. Then turn off the default base environment (ref 2)  
+        `conda config --set auto_activate_base false`  
+    
+Run this version of `conda env create` from the comments and gist in references (1) & (4), respectively  
+`CONDA_SUBDIR=osx-arm64 conda env create -f environment_AppleM1.yml`
+
+## Known issues
+Conducting step 3. appears to require using the full path to conda environments to invoke `conda activate <my_env>` which can be found using `conda env --list`.
+
+## Contact Information
+ntsteven@uw.edu
+
+## References
+environment_AppleM1.yml install instructions based on: 
+(1) https://gist.github.com/corajr/a10af2f893c4b79275281f6b6fd915d3  
+(2) https://caffeinedev.medium.com/how-to-install-tensorflow-on-m1-mac-8e9b91d93706  
+(3) https://github.com/conda-forge/miniforge  
+(4) https://developer.apple.com/forums/thread/711792  

--- a/environments/TensorFlow_AppleSilicon_Install.md
+++ b/environments/TensorFlow_AppleSilicon_Install.md
@@ -26,8 +26,7 @@ These paths can be found using
 Nathan Stevens:
 ntsteven@uw.edu
 
-## References
-environment_AppleM1.yml install instructions based on:  
+## References 
 (1) https://gist.github.com/corajr/a10af2f893c4b79275281f6b6fd915d3  
 (2) https://caffeinedev.medium.com/how-to-install-tensorflow-on-m1-mac-8e9b91d93706  
 (3) https://github.com/conda-forge/miniforge  

--- a/environments/environment_AppleM1.yml
+++ b/environments/environment_AppleM1.yml
@@ -1,0 +1,35 @@
+name: mlgeoM1
+channels:
+  - apple
+  - conda-forge
+  - pytorch
+dependencies:
+  - python=3.9
+  - jupyterlab
+  - pyarrow
+  - plotly
+  - geopandas
+  - matplotlib
+  - numpy
+  - scipy
+  - pandas
+  - rasterio
+  - scikit-learn
+  - shapely
+  - netcdf4
+  - wget
+  - h5py
+  - zarr
+  - xarray
+  - obspy
+  - folium
+  - seaborn
+  - pytorch
+  - torchvision
+  - keras
+  - pip
+  - tensorflow==2.9.1
+  - tensorflow-deps==2.9
+  - pip:
+    - tensorflow-macos
+    - tensorflow-metal

--- a/environments/environment_TF_Apple.yml
+++ b/environments/environment_TF_Apple.yml
@@ -1,0 +1,12 @@
+name: tensorflow-metal
+channels:
+  - apple
+  - conda-forge
+dependencies:
+  - nomkl
+  - tensorflow==2.9.1
+  - tensorflow-deps==2.9
+  - pip
+  - pip:
+    - tensorflow-macos
+    - tensorflow-metal


### PR DESCRIPTION
Documentation and two examples on how to, on Apple M1 and M2 chips, install a broad-based ML conda environment based on the MLGeo instructional environment (UW ESS 469/569) and a stripped-down version for installing just TensorFlow2 and necessary dependencies.